### PR TITLE
Add missing declare keyword in Typescript definition file

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,3 +1,3 @@
 type transform = <T = any>(xml: string, transform: object) => T;
-const camaro: transform;
+declare const camaro: transform;
 export = camaro;


### PR DESCRIPTION
At the moment the compiler throws an error

```
node_modules/camaro/index.d.ts:2:1 - error TS1046: A 'declare' modifier is required for a top level declaration in a .d.ts file.

2 const camaro: transform;
  ~~~~~
```