### PR TITLE
Fix index.d.ts definition

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,5 +1,5 @@
 type transform = <T = any>(xml: string, template: object) => T;
 type toJson = <T = any>(xml: string) => T;
 type prettyPrint = <T = any>(xml: string) => T;
-declare const camaro: { transform, toJson, prettyPrint };
+declare const camaro: { transform: transform, toJson: toJson, prettyPrint: prettyPrint };
 export = camaro;


### PR DESCRIPTION
Adding camaro@4.0.5 in TS project givers next compilation error:
```
> tsc --project tsconfig.dist.json 

node_modules/camaro/index.d.ts(4,25): error TS7008: Member 'transform' implicitly has an 'any' type.
node_modules/camaro/index.d.ts(4,36): error TS7008: Member 'toJson' implicitly has an 'any' type.
node_modules/camaro/index.d.ts(4,44): error TS7008: Member 'prettyPrint' implicitly has an 'any' type.
```

This PR fix the errors.