### PR TITLE
fix: update typescript definitions for recent API changes

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,5 +1,7 @@
-type transform = <T = any>(xml: string, template: object) => T;
-type toJson = <T = any>(xml: string) => T;
-type prettyPrint = <T = any>(xml: string) => T;
-declare const camaro: { transform: transform, toJson: toJson, prettyPrint: prettyPrint };
+declare const camaro: {
+    prettyPrint(xml: string, opts?: { indentSize: number }): Promise<string>;
+    toJson(xml: string): Promise<any>;
+    transform(xml: string, template: object): Promise<any>;
+};
+
 export = camaro;


### PR DESCRIPTION
This PR simply adjusts the typescript definitions for the recent API changes. It also adjusts the form of the definitions to align with best practices (specifically, the removal of [unnecessary generics](https://github.com/Microsoft/dtslint/blob/master/docs/no-unnecessary-generics.md)).

This should be fairly self-explanatory, but if not let me know if you have any questions/concerns and I'd be happy to address them.

Thanks!