### PR TITLE
ci: change to ubuntu-latest and macOS-latest

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -26,7 +26,7 @@ jobs:
 
   - job: Linux
     pool:
-      vmImage: "Ubuntu 16.04"
+      vmImage: "ubuntu-latest"
 
     variables:
       os_name: Linux
@@ -53,7 +53,7 @@ jobs:
 
   - job: OSX
     pool:
-      vmImage: "macOS 10.13"
+      vmImage: "macOS-latest"
 
     variables:
       os_name: OSX

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,4 +1,5 @@
 declare const camaro: {
+    ready(): Promise<void>;
     prettyPrint(xml: string, opts?: { indentSize: number }): Promise<string>;
     toJson(xml: string): Promise<any>;
     transform(xml: string, template: object): Promise<any>;


### PR DESCRIPTION
use `ubuntu-latest` and `macOS-latest` as `vmImage`

- fix: macOS CI jobs keep being cancelled 
- fix: missing `ready` method in `index.d.ts`