### PR TITLE
Add destroy method for graceful shutdown of worker pool

### DIFF
--- a/index.js
+++ b/index.js
@@ -71,4 +71,13 @@ function prettyPrint(xml, opts = { indentSize: 2 }) {
     return pool.run({ fn: 'prettyPrint', args: [xml, opts] })
 }
 
-module.exports = { transform, toJson, prettyPrint }
+/**
+ * destroy the worker pool
+ */
+function destroy() {
+    if (pool && typeof pool.destroy === 'function') {
+        return pool.destroy();
+    }
+}
+
+module.exports = { transform, toJson, prettyPrint, destroy }


### PR DESCRIPTION
I'm experiencing the following issue when running e2e tests using Jest:
```
Jest has detected the following 1 open handle potentially keeping Jest from exiting:

  ●  Piscina

    > 39 | import { transform } from 'camaro';
         | ^

      at new EventEmitterReferencingAsyncResource (node_modules/eventemitter-asyncresource/src/index.ts:23:5)
      at new EventEmitterAsyncResource (node_modules/eventemitter-asyncresource/src/index.ts:46:7)
      at new Piscina (node_modules/piscina/src/index.ts:893:5)
      at Object.<anonymous> (node_modules/camaro/index.js:13:12)
```

It appears a number of other folks may be running into this issue as well:
- https://github.com/piscinajs/piscina/issues/83
-  https://github.com/tuananh/camaro/issues/113#issuecomment-646836461

The goal of this PR is to provide a way to shutdown the worker pool in the event someone may be running into this.