### PR TITLE
Improve type for template object

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,8 +1,41 @@
-declare const camaro: {
-    prettyPrint(xml: string, opts?: { indentSize: number }): Promise<string>;
-    toJson(xml: string): Promise<any>;
-    transform(xml: string, template: object): Promise<any>;
-    destroy(): Promise<any>;
-};
+declare namespace camaro {
+  type Mapped<T> = T extends readonly []
+    ? []
+    : T extends ""
+    ? ""
+    : T extends `boolean(${string}`
+    ? boolean
+    : T extends `count(${string}`
+    ? number
+    : T extends `ceiling(${string}`
+    ? number
+    : T extends `floor(${string}`
+    ? number
+    : T extends `number(${string}`
+    ? number
+    : T extends `sum(${string}`
+    ? number
+    : T extends string
+    ? string
+    : T extends readonly [string, infer X]
+    ? X extends Readonly<Record<string, any>>
+      ? Transformed<X>[]
+      : Mapped<X>[]
+    : never;
+  export type Transformed<T extends Record<string, any>> = {
+    readonly [K in keyof T]: Mapped<T[K]>;
+  };
+
+  export function prettyPrint(
+    xml: string,
+    opts?: { indentSize: number }
+  ): Promise<string>;
+  export function toJson(xml: string): Promise<any>;
+  export function transform<const T extends Record<string, any>>(
+    xml: string,
+    template: T
+  ): Promise<Transformed<T>>;
+  export function destroy(): Promise<void>;
+}
 
 export = camaro;

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,41 +1,37 @@
-declare namespace camaro {
-  type Mapped<T> = T extends readonly []
-    ? []
-    : T extends ""
-    ? ""
-    : T extends `boolean(${string}`
-    ? boolean
-    : T extends `count(${string}`
-    ? number
-    : T extends `ceiling(${string}`
-    ? number
-    : T extends `floor(${string}`
-    ? number
-    : T extends `number(${string}`
-    ? number
-    : T extends `sum(${string}`
-    ? number
-    : T extends string
-    ? string
-    : T extends readonly [string, infer X]
-    ? X extends Readonly<Record<string, any>>
-      ? Transformed<X>[]
-      : Mapped<X>[]
-    : never;
-  export type Transformed<T extends Record<string, any>> = {
-    readonly [K in keyof T]: Mapped<T[K]>;
-  };
+type Mapped<T> = T extends readonly []
+  ? []
+  : T extends ""
+  ? ""
+  : T extends `boolean(${string}`
+  ? boolean
+  : T extends `count(${string}`
+  ? number
+  : T extends `ceiling(${string}`
+  ? number
+  : T extends `floor(${string}`
+  ? number
+  : T extends `number(${string}`
+  ? number
+  : T extends `sum(${string}`
+  ? number
+  : T extends string
+  ? string
+  : T extends readonly [string, infer X]
+  ? X extends Readonly<Record<string, any>>
+    ? Transformed<X>[]
+    : Mapped<X>[]
+  : never;
+export type Transformed<T extends Record<string, any>> = {
+  readonly [K in keyof T]: Mapped<T[K]>;
+};
 
-  export function prettyPrint(
-    xml: string,
-    opts?: { indentSize: number }
-  ): Promise<string>;
-  export function toJson(xml: string): Promise<any>;
-  export function transform<const T extends Record<string, any>>(
-    xml: string,
-    template: T
-  ): Promise<Transformed<T>>;
-  export function destroy(): Promise<void>;
-}
-
-export = camaro;
+export function prettyPrint(
+  xml: string,
+  opts?: { indentSize: number }
+): Promise<string>;
+export function toJson(xml: string): Promise<any>;
+export function transform<const T extends Record<string, any>>(
+  xml: string,
+  template: T
+): Promise<Transformed<T>>;
+export function destroy(): Promise<void>;

--- a/index.d.ts
+++ b/index.d.ts
@@ -22,7 +22,7 @@ type Mapped<T> = T extends readonly []
     : Mapped<X>[]
   : never;
 export type Transformed<T extends Record<string, any>> = {
-  readonly [K in keyof T]: Mapped<T[K]>;
+  [K in keyof T]: Mapped<T[K]>;
 };
 
 export function prettyPrint(

--- a/package.json
+++ b/package.json
@@ -19,9 +19,9 @@
     "exports": {
         ".": {
             "require": "./index.js",
-            "import": "./index.mjs"
-        },
-        "./": "./"
+            "import": "./index.mjs",
+            "types": "./index.d.ts"
+        }
     },
     "repository": {
         "type": "git",


### PR DESCRIPTION
It uses a simpler type definition than the #90 solution, and supports using functions in properties to change types, which can be synchronized with the definition in C++ and does not increase too much additional maintenance cost.

The following syntax is currently supported
```ts
{
    emptyString: '',
    emptyArray: [],
    boolean: 'boolean(/boolean)', // mapped to boolean
    number: 'number(/number)',
    stringArray: ['/strings', '.'], // mapped to string[]
    objectArray: ['/objects', {
        value: '/value',
        nested: ['/nested', {
            item: 'name',
            items: ['/props', '.']
        }]
    }]
}
```