### PR TITLE
Replace -Ofast with -O3 to fix NaN handling in Clang 17 (v3)

### DIFF
--- a/binding.gyp
+++ b/binding.gyp
@@ -13,7 +13,7 @@
       '-fexceptions',
       '-Wall',
       '-mtune=native',
-      '-Ofast',
+      '-O3',
       '-flto'
     ],
     'conditions': [
@@ -44,7 +44,7 @@
         '-fexceptions',
         '-Wall',
         '-mtune=native',
-        '-Ofast'
+        '-O3'
       ],
       'OTHER_LDFLAGS':[
         '-stdlib=libc++'


### PR DESCRIPTION
This PR aims to fix issue https://github.com/tuananh/camaro/issues/162

As noted in the issue, `number(@attr)` in v3 parses incorrectly if the attribute is missing or empty on systems using clang 17.0.0 (shipped with the latest macOS 15.4.1).

This PR replaces `-Ofast` with `-O3` in binding.gyp as `-Ofast` causes unexpected behaviour