### PR TITLE
transform() example from README.md does not compile

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -25,6 +25,12 @@ export type Transformed<T extends Record<string, any>> = {
   [K in keyof T]: Mapped<T[K]>;
 };
 
+type TransformResult<T> = T extends readonly [string, any]
+    ? Mapped<T>
+    : T extends Record<string, any>
+    ? Transformed<T>
+    : never;
+
 export type XmlInput = string | Uint8Array | ArrayBuffer | Buffer;
 
 export function prettyPrint(
@@ -32,8 +38,5 @@ export function prettyPrint(
   opts?: { indentSize: number }
 ): Promise<string>;
 export function toJson(xml: XmlInput): Promise<any>;
-export function transform<const T extends Record<string, any>>(
-  xml: XmlInput,
-  template: T
-): Promise<Transformed<T>>;
+export function transform<const T>(xml: XmlInput, template: T): Promise<TransformResult<T>>;
 export function destroy(): Promise<void>;


### PR DESCRIPTION
Example based on README.md fails compilation:
```
import { transform } from "camaro";

const xml = `
    <players>
        <player jerseyNumber="10">
            <name>wayne rooney</name>
            <isRetired>false</isRetired>
            <yearOfBirth>1985</yearOfBirth>
        </player>
        <player jerseyNumber="7">
            <name>cristiano ronaldo</name>
            <isRetired>false</isRetired>
            <yearOfBirth>1985</yearOfBirth>
        </player>
        <player jerseyNumber="7">
            <name>eric cantona</name>
            <isRetired>true</isRetired>
            <yearOfBirth>1966</yearOfBirth>
        </player>
    </players>
`

const result = await transform(xml, ['players/player', {
    name: 'title-case(name)',
    jerseyNumber: '@jerseyNumber',
    yearOfBirth: 'number(yearOfBirth)',
    isRetired: 'boolean(isRetired = "true")'
}]);

console.log(result[0].name); // <- error TS2339: Property 'name' does not exist on type 'string'.
```

With this fix, code compiles correctly.